### PR TITLE
Resolve connection error for product fetching

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 
-const API_BASE_URL = 'http://localhost:5000/api';
+const API_BASE_URL = '/api';
 
 class ApiClient {
   private baseURL: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,14 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/api/, '/api')
+      }
+    }
   },
   plugins: [
     react(),


### PR DESCRIPTION
Configure Vite proxy and update API base URL to resolve frontend-backend connection error.

The frontend was unable to fetch products due to a direct API call to `http://localhost:5000/api` from the Vite development server, leading to connection issues. This PR adds a proxy configuration in `vite.config.ts` to forward `/api` requests to the backend at `http://localhost:5000` and updates `src/lib/api.ts` to use the relative `/api` path, ensuring proper communication.